### PR TITLE
Updated addon to work with Blender 2.90

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-# BlenderToXenkoAnimationSeparator
-A blender 2.8 script that exports actions as separate fbx files for use in Xenko.
+# BlenderToStrideAnimationSeparator
+A Blender 2.9 addon that exports actions as separate fbx files for use in the [Stride3D Engine](https://github.com/stride3d/stride).
 
 ## Usage
-Install the addon and push f3 (windows default) to open the search. Type in Split Animation Export and select it. It will export all actions that are saved using a fake user (have the little F next to them) as individual fbx files in the same folder as your .blend file. The naming scheme is blendfilename_action.fbx. Import to xenko. Every fbx contains a single action, the mesh, and the skeleton.
+Install the addon and select ```File > Export > Split and Export Animations```. It will export all actions that are saved using a fake user (have the little shield with a checkmark next to them) as individual fbx files in the same folder as your .blend file. The naming scheme is blendfilename_action.fbx. Import to Stride. Every fbx contains a single action, the mesh, and the skeleton.
+
+You can also search for Split and Export Animations in the f3 menu.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # BlenderToStrideAnimationSeparator
-A Blender 2.9 addon that exports actions as separate fbx files for use in the [Stride3D Engine](https://github.com/stride3d/stride).
+A Blender 2.90 addon that exports actions as separate fbx files for use in the [Stride3D Engine](https://github.com/stride3d/stride).
 
 ## Usage
 Install the addon and select ```File > Export > Split and Export Animations```. It will export all actions that are saved using a fake user (have the little shield with a checkmark next to them) as individual fbx files in the same folder as your .blend file. The naming scheme is blendfilename_action.fbx. Import to Stride. Every fbx contains a single action, the mesh, and the skeleton.

--- a/io_export_animationseparator.py
+++ b/io_export_animationseparator.py
@@ -1,8 +1,8 @@
 bl_info = {
-        "name":         "Fbx Animation Splitter for Xenko",
+        "name":         "Fbx Animation Splitter for Stride3D Engine",
         "category":     "Import-Export",
-        "version":      (0,0,2),
-        "blender":      (2,80,0),
+        "version":      (0,0,3),
+        "blender":      (2,90,0),
         "location":     "File > Import-Export",
         "description":  "Split Animation Export",
         "category":     "Import-Export"
@@ -56,13 +56,15 @@ class SplitAnimations(bpy.types.Operator):
         return {'FINISHED'}
 
 def menu_func(self, context):
-    self.layout.operator(operator.SplitAnimations.bl_idname, text="SplitAnimations")
+    self.layout.operator(SplitAnimations.bl_idname)
 
 def register():
     bpy.utils.register_class(SplitAnimations)
+    bpy.types.TOPBAR_MT_file_export.append(menu_func)
     
 def unregister():
-    bpy.utils.register_class(SplitAnimations)
+    bpy.utils.unregister_class(SplitAnimations)
+    bpy.types.TOPBAR_MT_file_export.remove(menu_func)
 
 if __name__ == "__main__":
     register()


### PR DESCRIPTION
I closed the original pull request so I could move it to its own branch.

Blender 2.90 changed how searching for operators works. This pull request updates the addon to work with the new search method by adding an option to the ```File > Export``` menu. It also updates the README where appropriate.

Fixes https://github.com/GutterLab/BlenderToXenkoAnimationSeparator/issues/1